### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/lib/external/slepian_alpha/README.md
+++ b/lib/external/slepian_alpha/README.md
@@ -1,6 +1,6 @@
 # slepian_alpha
 
 ##Obtain first release
-The first release, 1.0.0, is deposited in Zenodo (http://dx.doi.org/10.5281/zenodo.15704).
+The first release, 1.0.0, is deposited in Zenodo (https://doi.org/10.5281/zenodo.15704).
 
-[![DOI](https://zenodo.org/badge/7664/csdms-contrib/slepian_alpha.svg)](http://dx.doi.org/10.5281/zenodo.15704)
+[![DOI](https://zenodo.org/badge/7664/csdms-contrib/slepian_alpha.svg)](https://doi.org/10.5281/zenodo.15704)

--- a/lib/external/slepian_alpha/README_Alpha.txt
+++ b/lib/external/slepian_alpha/README_Alpha.txt
@@ -11,7 +11,7 @@ use:
 Frederik J. Simons, F. A. Dahlen, and Mark A. Wieczorek
 Spatiospectral Concentration on a Sphere
 SIAM Rev., 48(3), 2006, 504-536.
-http://dx.doi.org/10.1137/S0036144504445765
+https://doi.org/10.1137/S0036144504445765
 
 
 Where do I start?

--- a/lib/external/slepian_bravo/README.md
+++ b/lib/external/slepian_bravo/README.md
@@ -1,6 +1,6 @@
 # slepian_bravo
 
 ##Obtain first release
-The first release, 1.0.0, is deposited in Zenodo (http://dx.doi.org/10.5281/zenodo.15705).
+The first release, 1.0.0, is deposited in Zenodo (https://doi.org/10.5281/zenodo.15705).
 
-[![DOI](https://zenodo.org/badge/7664/csdms-contrib/slepian_bravo.svg)](http://dx.doi.org/10.5281/zenodo.15705)
+[![DOI](https://zenodo.org/badge/7664/csdms-contrib/slepian_bravo.svg)](https://doi.org/10.5281/zenodo.15705)


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8) and Zenodo started using it for its badges as well. Accordingly, this PR updates all DOI links.

Cheers!